### PR TITLE
Add secrets flag, upgrade dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #---------------
 #--- Builder ---
 #---------------
-FROM docker.io/library/golang:1.22-alpine AS builder
+FROM docker.io/library/golang:1.24-alpine AS builder
 
 COPY [".", "/bnet"]
 WORKDIR /bnet

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"net/http"
 	"time"
 
@@ -10,8 +11,8 @@ import (
 )
 
 const (
-	secretFile = "secrets/secret.toml"
-	host       = ":8080"
+	defaultSecretsFile = "secrets/secret.toml"
+	host               = ":8080"
 )
 
 type Secrets struct {
@@ -21,8 +22,12 @@ type Secrets struct {
 }
 
 func main() {
-	secrets, _, err := fileload.TOML[Secrets](secretFile)
-	logging.FatalIfError(err, secretFile)
+	// Allow the user to specify a different secrets file
+	secretsFile := flag.String("secrets", defaultSecretsFile, "Full path to the secrets file")
+	flag.Parse()
+
+	secrets, _, err := fileload.TOML[Secrets](*secretsFile)
+	logging.FatalIfError(err, *secretsFile)
 
 	srv := bnet.NewServer(secrets.ClientID, secrets.ClientSecret, secrets.RedirectURL)
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module github.com/seanpfeifer/bnet-id
 
-go 1.22.3
+go 1.24
+
+toolchain go1.24.3
 
 require (
-	github.com/seanpfeifer/rigging v0.3.4
-	golang.org/x/oauth2 v0.20.0
+	github.com/seanpfeifer/rigging v0.4.1
+	golang.org/x/oauth2 v0.30.0
 )
 
-require github.com/BurntSushi/toml v1.4.0 // indirect
+require github.com/BurntSushi/toml v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
-github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
-github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/seanpfeifer/rigging v0.3.4 h1:RuPBl2JalYHRWzBdaaJhetyPTafsUWfZcE9v+WLVsEU=
-github.com/seanpfeifer/rigging v0.3.4/go.mod h1:/CIqSr9gnOhBzRcFC98erYn8tggLuIVZaWBgoXOSxF0=
-golang.org/x/oauth2 v0.20.0 h1:4mQdhULixXKP1rwYBW0vAijoXnkTG0BLCDRzfe1idMo=
-golang.org/x/oauth2 v0.20.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/seanpfeifer/rigging v0.4.1 h1:AMsMPIUpTUizcwBXX0FPh9x1i60o83Big8EZVe7QIl4=
+github.com/seanpfeifer/rigging v0.4.1/go.mod h1:s6tgg7SuosGSmwroVDd02wdZ7tuWEl45lE6DWfAGR9w=
+golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=


### PR DESCRIPTION
This adds the `-secrets` flag in order to specify where exactly the secrets file resides.

This allows users to use platforms that may mount secrets without full file extensions.

This PR also bumps to Go revision and upgrades dependencies.